### PR TITLE
removed duplicate esc_attr. fixed class and alt_text argument parsing

### DIFF
--- a/modules/helpers-html/helpers-html.php
+++ b/modules/helpers-html/helpers-html.php
@@ -639,14 +639,11 @@ HTML;
 			) );
 
 			if ( $args['alt_text'] ) {
-				$args['alt_text'] = esc_attr( $args['alt_text'] );
-				$args['alt_text'] = " alt=\"{$args['alt_text']}\"";
-				$args['alt_text'] = ' alt=' . esc_attr( $args['alt_text'] ) . '"';
+				$args['alt_text'] = ' alt="' . esc_attr( $args['alt_text'] ) . '"';
 			}
 
 			if ( $args['class'] ) {
-				$args['class'] = esc_attr( $args['class'] );
-				$args['class'] = ' class=' . esc_attr( $args['class'] ) . '"';
+				$args['class'] = ' class="' . esc_attr( $args['class'] ) . '"';
 			}
 
 			$args['attributes'] = self::get_html_attributes_html( $args['attributes'] );


### PR DESCRIPTION
Both `$args['alt_text']` and `$args['class']` attributes were missing double quotes before the argument was concatenated. Also, both attributes were being passed through the `esc_attr()` function twice.
