### PR TITLE
fixed get_html_attributes_html()

### DIFF
--- a/modules/helpers-html/helpers-html.php
+++ b/modules/helpers-html/helpers-html.php
@@ -487,7 +487,7 @@ HTML;
 
 			function( $name ) use ( $attributes ) {
 
-				return "{$name}=\"{$attributes[ $value ]}\"";
+				return "{$name}=\"{$attributes[ $name ]}\"";
 
 			},
 			array_keys( $attributes )


### PR DESCRIPTION
This method was breaking with **"`$value` is undefined"**. It is called by `WPLib::getLink()`, so, quite important. 