### PR TITLE
Fix for $theme->get_post_list() and some other list methods

### DIFF
--- a/includes/class-item-base.php
+++ b/includes/class-item-base.php
@@ -66,12 +66,12 @@ abstract class WPLib_Item_Base extends WPLib_Base {
 
 				}
 
-				if ( method_exists( $class_name, 'make_new' ) ) {
+				if ( method_exists( $class_name, 'make_new_item' ) ) {
 					/*
 					 * If this class has a make_new() method.
-					 * A Class::make_new() method is needed when the class constructor has more than 1 parameter of $args.
+					 * A Class::make_new_item() method is needed when the class constructor has more than 1 parameter of $args.
 					 */
-					$this->{$property_name} = $class_name::make_new( $property_args );
+					$this->{$property_name} = $class_name::make_new_item( $property_args );
 
 				} else if ( class_exists( $class_name ) ) {
 

--- a/includes/class-item-base.php
+++ b/includes/class-item-base.php
@@ -66,12 +66,12 @@ abstract class WPLib_Item_Base extends WPLib_Base {
 
 				}
 
-				if ( method_exists( $class_name, 'make_new_item' ) ) {
+				if ( method_exists( $class_name, 'make_new' ) ) {
 					/*
 					 * If this class has a make_new() method.
-					 * A Class::make_new_item() method is needed when the class constructor has more than 1 parameter of $args.
+					 * A Class::make_new() method is needed when the class constructor has more than 1 parameter of $args.
 					 */
-					$this->{$property_name} = $class_name::make_new_item( $property_args );
+					$this->{$property_name} = $class_name::make_new( $property_args );
 
 				} else if ( class_exists( $class_name ) ) {
 

--- a/includes/class-module-base.php
+++ b/includes/class-module-base.php
@@ -45,7 +45,7 @@ abstract class WPLib_Module_Base extends WPLib {
 	 *      @type string $instance_class    The class for items in the list, i.e. WP_Post
 	 * }
 	 *
-	 * @return WPLib_List_Default[]
+	 * @return WPLib_List_Default
 	 *
 	 */
 	static function get_list( $query = array(), $args = array() ) {

--- a/includes/class-theme-base.php
+++ b/includes/class-theme-base.php
@@ -571,9 +571,10 @@ abstract class WPLib_Theme_Base extends WPLib_Base {
 		if( $this->has_posts() ) {
 			$_post = $this->post();
 			$item  = WPLib_Posts::make_new_item( $_post, "list_owner=" );
-			if( !$item ){
-				$item  = new WPLib_Post_Default( $_post );
-			}
+			/**
+			 * Note, $item will be instance of WPLib_Post_Default for posts where
+			 * post type is registered by other means than standard WPLib way.
+			 */
 		} else {
 			$item  = new WPLib_Post_Default( null );
 		}

--- a/modules/post-type-page/includes/class-page.php
+++ b/modules/post-type-page/includes/class-page.php
@@ -22,7 +22,12 @@ class WPLib_Page extends WPLib_Post_Base {
 	 */
 	const POST_TYPE = WPLib_Post_Type_Page::POST_TYPE;
 
-
+	/**
+	 * Used by the_template() to assign an instance of this class to variable with this name.
+	 *
+	 * @var string
+	 */
+	const VAR_NAME = 'page_item';
 }
 
 

--- a/modules/post-type-page/post-type-page.php
+++ b/modules/post-type-page/post-type-page.php
@@ -5,8 +5,9 @@
  */
 class WPLib_Post_Type_Page extends WPLib_Module_Base {
 
-	const POST_TYPE = 'page';
+	const POST_TYPE      = 'page';
 
+	const INSTANCE_CLASS = 'WPLib_Page';
 }
 
 

--- a/modules/post-type-post/includes/class-post.php
+++ b/modules/post-type-post/includes/class-post.php
@@ -22,7 +22,12 @@ class WPLib_Post extends WPLib_Post_Base {
 	 */
 	const POST_TYPE = 'post';
 
-
+	/**
+	 * Used by the_template() to assign an instance of this class to variable with this name.
+	 *
+	 * @var string
+	 */
+	const VAR_NAME = 'post_item';
 }
 
 

--- a/modules/post-type-post/post-type-post.php
+++ b/modules/post-type-post/post-type-post.php
@@ -5,8 +5,9 @@
  */
 class WPLib_Post_Type_Post extends WPLib_Module_Base {
 
-	const POST_TYPE = 'post';
+	const POST_TYPE      = 'post';
 
+	const INSTANCE_CLASS = 'WPLib_Post';
 }
 
 

--- a/modules/posts/includes/class-post-list-base.php
+++ b/modules/posts/includes/class-post-list-base.php
@@ -27,11 +27,11 @@ class WPLib_Post_List_Base extends WPLib_List_Base {
 			 */
 			$list_owner = $args['list_owner'];
 
-			if ( ! $list_owner ) {
+			if ( $list_owner ) {
 
 				foreach ($posts as $index => $post) {
 
-					$posts[$index] = $list_owner::make_new_item( $post, $args );
+					$posts[ $index ] = $list_owner::make_new_item( $post, $args );
 
 				}
 
@@ -40,7 +40,7 @@ class WPLib_Post_List_Base extends WPLib_List_Base {
 				foreach ($posts as $index => $post) {
 
 					$list_owner = $args['list_owner'] = WPLib_Posts::get_post_type_class( $post->post_type );
-					$posts[$index] = $list_owner::make_new_item( $post, $args );
+					$posts[ $index ] = $list_owner::make_new_item( $post, $args );
 
 				}
 

--- a/modules/posts/includes/class-post-list-base.php
+++ b/modules/posts/includes/class-post-list-base.php
@@ -56,26 +56,30 @@ class WPLib_Post_List_Base extends WPLib_List_Base {
 						continue;
 					}
 
-					if ( ! WPLib::can_call( 'make_new', $instance_class ) ) {
-
-						if ( ! WPLib::can_call( 'make_new_item', $instance_class ) ) {
-							/**
-							 * Method name make_new_item() is discouraged, supported here just for compatibility with existing projects.
-							 */
-							WPLib::trigger_error( sprintf( "Since class '%s' is being used as an item class, it should have make_new() callable!", $instance_class ) );
-							continue;
-						} else {
-							$posts[ $index ] = $instance_class::make_new_item( $post, $args );
-						}
-
-					} else {
+					if ( WPLib::can_call( 'make_new', $instance_class ) ) {
 						$posts[ $index ] = $instance_class::make_new( $post, $args );
+						continue;
 					}
 
+					if ( ! WPLib::can_call( 'make_new_item', $instance_class ) ) {
+						/**
+						 * Backwards compatibility for old projects that do not use the idiomatic method name "make_new()".
+						 */
+						$posts[ $index ] = $instance_class::make_new_item( $post, $args );
+						continue;
+					}
 
+					if( 'WPLib_Post_Default' == $instance_class ) {
+						/**
+						 * Most likely this is a post registered by other means than the standard WPLib-way.
+						 */
+						$posts[ $index ] = new $instance_class( $post );
+						continue;
+					}
+
+					WPLib::trigger_error( sprintf( "Since class '%s' is being used as an item class, it should have make_new() callable!", $instance_class ) );
 
 				}
-
 			}
 		}
 

--- a/modules/posts/includes/class-post-model-base.php
+++ b/modules/posts/includes/class-post-model-base.php
@@ -248,7 +248,10 @@ abstract class WPLib_Post_Model_Base extends WPLib_Model_Base {
 
 		}
 
-		if ( $this->has_post() &&  $this->_post->post_type !== $post_type ) {
+		/**
+		 * When $post_type == 'any', that (most likely) means that post type was not created by WPLib.
+		 */
+		if ( $post_type != 'any' && $this->has_post() &&  $this->_post->post_type !== $post_type ) {
 
 			$message = __( "Post type mismatch: %s::POST_TYPE=='%s' while \$this->_post->post_type=='%s'.", 'wplib' );
 			WPLib::trigger_error( sprintf( $message, get_class( $this->owner ), $post_type, $this->_post->post_type ) );

--- a/modules/posts/includes/class-post-module-base.php
+++ b/modules/posts/includes/class-post-module-base.php
@@ -152,7 +152,7 @@ abstract class WPLib_Post_Module_Base extends WPLib_Module_Base {
 	 *      @type string $queried             'local' or 'queried'
 	 * }
 	 *
-	 * @return WPLib_Post_List_Default[]
+	 * @return WPLib_Post_List_Default
 	 */
 	static function get_list( $query = array(), $args = array() ) {
 

--- a/modules/posts/posts.php
+++ b/modules/posts/posts.php
@@ -498,6 +498,9 @@ class WPLib_Posts extends WPLib_Module_Base {
 				case 'page':
 					$instance_class = 'WPLib_Page';
 					break;
+				default:
+					$instance_class = 'WPLib_Post_Default';
+					break;
 			}
 		}
 

--- a/modules/posts/posts.php
+++ b/modules/posts/posts.php
@@ -15,9 +15,9 @@ class WPLib_Posts extends WPLib_Module_Base {
 	private static $_default_labels;
 
 	/**
-	 * The post type labels
+	 * The labels for every post type
 	 *
-	 * @var string[]
+	 * @var array[]
 	 */
 	private static $_labels = array();
 
@@ -32,7 +32,7 @@ class WPLib_Posts extends WPLib_Module_Base {
 	/**
 	 * Value to limit the maximum posts per page requested for any given WP_Query
 	 *
-	 * @var array|null
+	 * @var int|null
 	 */
 	private static $_max_posts_per_page = 999;
 
@@ -298,7 +298,7 @@ class WPLib_Posts extends WPLib_Module_Base {
 	/**
 	 * @param array|string|WPLib_Query $query
 	 * @param array $args
-	 * @return WPLib_Post_List_Default
+	 * @return WPLib_Post_List_Default|WPLib_List_Default
 	 */
 	static function get_list( $query = array(), $args = array() ) {
 

--- a/modules/terms/includes/class-term-module-base.php
+++ b/modules/terms/includes/class-term-module-base.php
@@ -10,12 +10,12 @@ abstract class WPLib_Term_Module_Base extends WPLib_Module_Base {
 	const INSTANCE_CLASS = null;
 
 	/**
-	 * REgister the labels used for this taxonomy.
+	 * Register the labels used for this taxonomy.
 	 *
 	 * @param array $args
 	 * @future Allow taxonomy name to be passed optionally.
 	 *
-	 * @return object
+	 * @return array
 	 */
 	static function register_taxonomy_labels( $args = array() ) {
 

--- a/wplib.php
+++ b/wplib.php
@@ -2108,6 +2108,29 @@ class WPLib {
 				$_module_class
 			);
 
+			/*
+			 * Make $theme available inside the template.
+			 */
+			$theme = WPLib::theme();
+
+			if ( WPLib::use_template_global_vars() ) {
+
+				/*
+				 * For compatibility with WordPress templates we need to
+				 * extract all the global variables into the current scope just
+				 * like WordPress does when it calls a template. Ironically
+				 * some code sniffers constantly flag extract() so it is easier to
+				 * hide it than to have to constantly see it flagged.
+				 *
+				 * OTOH if you are using WPLib and you think we should do a direct call
+				 * to extract() here please add an issue so we can discuss the pros and
+				 * cons at https://github.com/wplib/wplib/issues
+				 */
+
+				extract( $GLOBALS, EXTR_SKIP );
+
+			}
+
 			ob_start();
 
 			self::$_file_loading = $template->filename;


### PR DESCRIPTION
* Fix WPLib_Post_List_Base constructor so that WPLib_Theme_Base->get_post_list() does not  throw a fatal error.
* Fix WPLib_Item_Base constructor to call make_new_item() rather than make_new().
* More accurate type hints in docblocks.