### PR TITLE
[PHP 8.3] Fix `get_parent_class()` deprecation

### DIFF
--- a/modules/role-administrator/role-administrator.php
+++ b/modules/role-administrator/role-administrator.php
@@ -58,7 +58,7 @@ class WPLib_Administrators extends WPLib_Administrator_Module_Base {
 
 		} else {
 
-			$capabilities = call_user_func( array( get_parent_class(), 'get_capabilities' ), $class_name );
+			$capabilities = call_user_func( array( parent::class, 'get_capabilities' ), $class_name );
 
 			$capabilities = array_merge( $parent_capabilities, $capabilities );
 


### PR DESCRIPTION
In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

This fixes one instance with an identical alternative that does not cause the deprecation notice.

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)